### PR TITLE
Standardize AppStream ID with "org.pitivi.Pitivi"

### DIFF
--- a/data/pitivi.appdata.xml.in
+++ b/data/pitivi.appdata.xml.in
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2013 Jean-François Fortin Tam <nekohayo@gmail.com> -->
 <component type="desktop">
-  <id>pitivi.desktop</id>
+  <id>org.pitivi.Pitivi</id>
+  <launchable type="desktop">pitivi.desktop</launchable>
   <metadata_license>CC-BY-3.0</metadata_license>
   <project_license>LGPL-2.0+</project_license>
   <_name>Pitivi</_name>


### PR DESCRIPTION
Pitivi [provides Flatpak metadata](https://github.com/GNOME/pitivi/blob/master/build/flatpak/pitivi.template.json), which is great!

However, [the AppStream ID in Pitivi's AppStream file](https://github.com/GNOME/pitivi/blob/master/data/pitivi.appdata.xml.in#L4) (`pitivi.desktop`) doesn't match the one chosen in the Flatpak file (`org.pitivi.Pitivi`). When AppStream IDs don't match, software center apps like GNOME Software and KDE Discover consider each one to be a separate app. So for users of these programs who have Pitivi available from Flathub as well as their distro's packages, Pitivi shows up twice, which is confusing:

![two pitivis](https://user-images.githubusercontent.com/1097249/34324055-ed1aea3a-e81f-11e7-96f1-7c41038d9a2f.png)

If you change the AppStream file to use `org.pitivi.Pitivi` as the AppStream ID for distro packaging, then the software could de-duplicate them and show the user a nice "which source do you want to install from?" UI. This patch does just that.
